### PR TITLE
Add requests basic auth and bytes toggle.

### DIFF
--- a/consul/aio.py
+++ b/consul/aio.py
@@ -64,7 +64,7 @@ class Consul(base.Consul):
         self._loop = loop or asyncio.get_event_loop()
         super().__init__(*args, **kwargs)
 
-    def connect(self, host, port, scheme, verify=True, cert=None):
+    def connect(self, host, port, scheme, verify=True, cert=None, auth=None):
         return HTTPClient(host, port, scheme, loop=self._loop,
                           verify=verify, cert=None)
 

--- a/consul/std.py
+++ b/consul/std.py
@@ -19,26 +19,26 @@ class HTTPClient(base.HTTPClient):
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert)))
+            self.session.get(uri, verify=self.verify, cert=self.cert, auth=self.auth)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.put(uri, data=data, verify=self.verify,
-                             cert=self.cert)))
+                             cert=self.cert, auth=self.auth)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.delete(uri, verify=self.verify, cert=self.cert)))
+            self.session.delete(uri, verify=self.verify, cert=self.cert, auth=self.auth)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.post(uri, data=data, verify=self.verify,
-                              cert=self.cert)))
+                              cert=self.cert, auth=self.auth)))
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify, cert)
+    def connect(self, host, port, scheme, verify=True, cert=None, auth=None):
+        return HTTPClient(host, port, scheme, verify, cert, auth)

--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -53,5 +53,5 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
+    def connect(self, host, port, scheme, verify=True, cert=None, auth=None):
         return HTTPClient(host, port, scheme, verify=verify, cert=cert)

--- a/consul/twisted.py
+++ b/consul/twisted.py
@@ -131,6 +131,7 @@ class Consul(base.Consul):
                 verify=True,
                 cert=None,
                 contextFactory=None,
+                auth=None,
                 **kwargs):
         return HTTPClient(
             contextFactory, host, port, scheme, verify=verify, cert=cert,


### PR DESCRIPTION
Two feature additions:
* can pass a `bytes` param to `get()` that will switch whether returned value is bytes or a decoded string.
* add ability to pass consul basic auth params to the requests lib by means of a `CONSUL_HTTP_AUTH` environment variable
The other HTTP libs have updated signatures but otherwise don't use the auth param. I haven't tested any of them.

This merge request should be targeting our fork, unless I screwed up the github interface.